### PR TITLE
Update copyToClipboard to use modern API

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -282,17 +282,16 @@ function displayRakutenProduct(rakutenData) {
 // ユーティリティ関数
 function copyToClipboard(elementId) {
     const element = document.getElementById(elementId);
-    element.select();
-    document.execCommand('copy');
-    
-    // コピー完了のフィードバック
-    const button = event.target.closest('button');
-    const originalContent = button.innerHTML;
-    button.innerHTML = '<i class="fas fa-check text-success"></i>';
-    
-    setTimeout(() => {
-        button.innerHTML = originalContent;
-    }, 1000);
+    navigator.clipboard.writeText(element.value).then(() => {
+        // コピー完了のフィードバック
+        const button = event.target.closest('button');
+        const originalContent = button.innerHTML;
+        button.innerHTML = '<i class="fas fa-check text-success"></i>';
+
+        setTimeout(() => {
+            button.innerHTML = originalContent;
+        }, 1000);
+    });
 }
 
 function updateRakutenData() {


### PR DESCRIPTION
## Summary
- use `navigator.clipboard.writeText` when copying fields to clipboard

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687a61abc5c883288583961ff4a62f6e